### PR TITLE
Fix Gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@
 [Dd]ebug/
 [Dd]ebugPublic/
 [Rr]elease/
-[Rr]eleases/
 x64/
 x86/
 [Aa][Rr][Mm]/


### PR DESCRIPTION
@ProtonDriveTeam the .gitignore in this repo seems to have prevented some code from being committed. The files under `src\ProtonDrive.Update\Releases` are all missing, which is preventing the application from both compiling and working as expected.

As an aside, there don't seem to be any instructions for properly building and debugging this repository as exists in the others.